### PR TITLE
Fix crashes in SolarSystem traits lookup and BlockOre state mapping

### DIFF
--- a/src/main/java/com/hbmspace/blocks/generic/BlockOre.java
+++ b/src/main/java/com/hbmspace/blocks/generic/BlockOre.java
@@ -307,6 +307,8 @@ public class BlockOre extends net.minecraft.block.BlockOre implements ICustomBlo
         return new StateMapperBase() {
             @Override
             protected @NotNull ModelResourceLocation getModelResourceLocation(@NotNull IBlockState state) {
+                if (!state.getPropertyKeys().contains(META))
+                    return new ModelResourceLocation(loc, "meta=0");
                 int meta = state.getValue(META);
                 if (meta < META_COUNT) return new ModelResourceLocation(loc, "meta=" + meta);
                 else return new ModelResourceLocation(loc, "meta=0");

--- a/src/main/java/com/hbmspace/dim/SolarSystemWorldSavedData.java
+++ b/src/main/java/com/hbmspace/dim/SolarSystemWorldSavedData.java
@@ -231,6 +231,7 @@ public class SolarSystemWorldSavedData extends WorldSavedData {
 	}
 
 	public static HashMap<Class<? extends CelestialBodyTrait>, CelestialBodyTrait> getClientTraits(String bodyName) {
+		if (clientTraits == null) return null;
 		return clientTraits.get(bodyName);
 	}
 	

--- a/src/main/java/com/hbmspace/mixin/mod/hbm/tileentities/MixinTileEntityOilDrillBase.java
+++ b/src/main/java/com/hbmspace/mixin/mod/hbm/tileentities/MixinTileEntityOilDrillBase.java
@@ -1,6 +1,5 @@
 package com.hbmspace.mixin.mod.hbm.tileentities;
 
-import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.fluid.tank.FluidTankNTM;
 import com.hbm.lib.ForgeDirection;
 import com.hbm.tileentity.machine.oil.TileEntityOilDrillBase;
@@ -30,7 +29,7 @@ public abstract class MixinTileEntityOilDrillBase {
 
     @Overwrite
     public boolean canSuckBlock(Block b) {
-        return (b instanceof BlockOreFluid && b != ModBlocks.ore_bedrock_oil) || BlockOreFluid.getFullBlock(b) != null;
+        return (b instanceof BlockOreFluid) || BlockOreFluid.getFullBlock(b) != null;
     }
 
     @Overwrite


### PR DESCRIPTION
SolarSystemWorldSavedData: Added a null check for `clientTraits` map. This prevents an NPE during early cloud rendering (before the server sync packet is processed).

BlockOre: Added a guard for the `META` property in `getStateMapper`. This prevents an `IllegalArgumentException` for blocks like `ore_bedrock_oil` that do not define this property in their state container.